### PR TITLE
fix: dark mode detecting

### DIFF
--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -12,11 +12,8 @@ export function useTheme() {
   }, [theme]);
 
   useEffect(() => {
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addListener(({ matches }) => {
-        setTheme(matches ? 'dark' : '');
-      });
+    const { matches } = window.matchMedia('(prefers-color-scheme: dark)');
+    matches && setTheme('dark');
   }, []);
 
   return [theme, setTheme];


### PR DESCRIPTION
**Summary**

Dark mode detecting was not working properly on my devices (MacOS Catalina / Chrome 81 and iPhone 6s / Safari 13.1) and application was always started with light theme.

**Result**

With this PR, application won't be starting with light theme always. If user prefers dark theme, it'll start with dark theme instead.
