### PR TITLE
Fixed link to how-do-we-build-an-index

### DIFF
--- a/docs/inside-the-engine.md
+++ b/docs/inside-the-engine.md
@@ -64,7 +64,7 @@ You could even change the relevancy strategy by [overwriting the default
 your config.
 
 [1]: https://www.sitemaps.org/
-[2]: how-do-we-build-an-index
+[2]: how-do-we-build-an-index.mdx
 [3]:
   https://www.algolia.com/doc/guides/ranking/ranking-formula/#tie-breaking-approach
 [4]: https://www.algolia.com/doc/guides/ranking/custom-ranking/

--- a/docs/required-configuration.md
+++ b/docs/required-configuration.md
@@ -126,7 +126,7 @@ index exposed via the DocSearch `custom_settings` parameter.
 
 Any questions? [Send us an email][6].
 
-[1]: how-do-we-build-an-index.md
+[1]: how-do-we-build-an-index.mdx
 [2]: config-file.md
 [3]: https://www.algolia.com/doc/guides/searching/filtering/#facet-filters
 [4]: https://www.sitemaps.org/


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

The link in https://docsearch.algolia.com/docs/required-configuration/ points to https://docsearch.algolia.com/docs/required-configuration/how-do-we-build-an-index.md which leads to an 404.

**Result**

Now the link should point to the correct URL https://docsearch.algolia.com/docs/how-do-we-build-an-index
