### PR TITLE
fix(demo): define a fallback project name

### DIFF
--- a/src/pages/demo.js
+++ b/src/pages/demo.js
@@ -44,6 +44,7 @@ function Demo() {
   );
 
   function resetCredentials() {
+    setProjectName(DEFAULT_INDEX_NAME);
     setIndexName(DEFAULT_INDEX_NAME);
     setApiKey(DEFAULT_API_KEY);
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->
This PR fix a current issue on the demo page. When no project are defined, the fallback is to demo DocSearch thanks to the DocSearch documentation. However the project name is missing as you can see on the following screenshot:
![image](https://user-images.githubusercontent.com/32097720/88885920-b3d0dd00-d239-11ea-9d67-856648b9aad4.png)
Note the missing project name on the right side of the heart and the blank within the text.


**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->

The default project name used is DocSearch:
![image](https://user-images.githubusercontent.com/32097720/88885991-e11d8b00-d239-11ea-8df6-1e9c62b5ab5d.png)

